### PR TITLE
Optimize Movement

### DIFF
--- a/client/network/socket.js
+++ b/client/network/socket.js
@@ -28,6 +28,10 @@ export async function joinRoom(scene, roomName) {
     console.log(`Attempting to join room: ${roomName}`);
     try {
         let playerAvatarData = getPlayerAvatarData(); // Get the player's avatar data
+        playerAvatarData.x = scene.playerXLocation;
+        playerAvatarData.y = scene.playerYLocation;
+        playerAvatarData.playerDirection = scene.playerDirection;
+
         if (!playerAvatarData) {
             console.error("❌ No avatar data found!");
             return;
@@ -37,7 +41,7 @@ export async function joinRoom(scene, roomName) {
         
         resetConnectionCheck(); // Reset the connection check
         console.log(`Successfully joined room: ${roomName}`);
-
+        
         currentRoom.onLeave(() => {
             if (!switchingRooms) {
                 console.error("❌ Lost connection to the game server!");
@@ -91,7 +95,7 @@ export async function joinRoom(scene, roomName) {
 
             // Find the player associated with the message
             const sender = id === scene.player.id ? scene.player : scene.otherPlayers[id];
-          
+        
             // Display the message for the corresponding player
             if (sender) {
                 displayChatBubble(scene, sender, message);
@@ -252,7 +256,6 @@ export async function joinRoom(scene, roomName) {
             }
         });
         
-
         return currentRoom;
     } catch (error) {
         console.error(`Failed to join room: ${roomName}`, error);
@@ -267,6 +270,7 @@ export async function joinRoom(scene, roomName) {
  * @param {number} y - The player's y-coordinate.
  */
 export function sendPlayerMove(room, x, y, direction) {
+    //SEND CLICK
     if (room) {
         room.send('move', { x, y, direction });
     }

--- a/client/scenes/Beach.js
+++ b/client/scenes/Beach.js
@@ -1,5 +1,5 @@
-import { setupMovement } from '../world/playerMovement.js';
-import { joinRoom, sendPlayerMove } from '../network/socket.js';
+import { stepMovementUpdates, setupMovement } from '../world/playerMovement.js';
+import { joinRoom } from '../network/socket.js';
 import { preloadAvatar, createAvatar } from '../world/avatar.js';
 import { initializePlayerManager } from '../world/playerManager.js';
 import { createRoomTransitionUI } from '../world/roomTransition.js';
@@ -59,9 +59,7 @@ export class Beach extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 }
 
@@ -104,9 +102,7 @@ export class DanceClub extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -153,9 +149,7 @@ export class TanStore extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }

--- a/client/scenes/Carnival.js
+++ b/client/scenes/Carnival.js
@@ -1,5 +1,5 @@
-import { setupMovement } from '../world/playerMovement.js';
-import { joinRoom, sendPlayerMove } from '../network/socket.js';
+import { stepMovementUpdates, setupMovement } from '../world/playerMovement.js';
+import { joinRoom } from '../network/socket.js';
 import { preloadAvatar, createAvatar } from '../world/avatar.js';
 import { initializePlayerManager } from '../world/playerManager.js';
 import { createRoomTransitionUI } from '../world/roomTransition.js';
@@ -54,9 +54,7 @@ export class Carnival extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 }
 
@@ -99,9 +97,7 @@ export class Arcade extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }

--- a/client/scenes/Castle.js
+++ b/client/scenes/Castle.js
@@ -1,5 +1,5 @@
-import { setupMovement } from '../world/playerMovement.js';
-import { joinRoom, sendPlayerMove } from '../network/socket.js';
+import { stepMovementUpdates, setupMovement } from '../world/playerMovement.js';
+import { joinRoom } from '../network/socket.js';
 import { preloadAvatar, createAvatar } from '../world/avatar.js';
 import { initializePlayerManager } from '../world/playerManager.js';
 import { createRoomTransitionUI } from '../world/roomTransition.js';
@@ -56,9 +56,7 @@ export class Castle extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -115,9 +113,7 @@ export class CastleYard extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 }
 
@@ -173,8 +169,6 @@ export class CastleInside extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 }

--- a/client/scenes/Downtown.js
+++ b/client/scenes/Downtown.js
@@ -1,5 +1,5 @@
-import { setupMovement } from '../world/playerMovement.js';
-import { joinRoom, sendPlayerMove } from '../network/socket.js';
+import { stepMovementUpdates, setupMovement } from '../world/playerMovement.js';
+import { joinRoom } from '../network/socket.js';
 import { preloadAvatar, createAvatar} from '../world/avatar.js';
 import { initializePlayerManager } from '../world/playerManager.js';
 import { createRoomTransitionUI } from '../world/roomTransition.js';
@@ -38,6 +38,7 @@ export class Downtown extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
+        
         createAvatarAnimations(this, this.player);
         performIdles(this.player);
 
@@ -61,7 +62,7 @@ export class Downtown extends Phaser.Scene {
 
         createMenu(this, this.player, this.room);
 
-        this.updateMovement = setupMovement(this, this.player, 200);
+        this.updateMovement = setupMovement(this);
 
         this.downtown_music = this.sound.add('downtown_music', { loop: true, volume: 0.5 });
         this.downtown_music.play();
@@ -69,10 +70,8 @@ export class Downtown extends Phaser.Scene {
 
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
-        
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -116,10 +115,8 @@ export class StarCafe extends Phaser.Scene {
     
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
-        
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -159,10 +156,8 @@ export class LeShop extends Phaser.Scene {
     
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
-        
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -202,10 +197,8 @@ export class Salon extends Phaser.Scene {
     
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
-        
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -249,10 +242,8 @@ export class TopModel extends Phaser.Scene {
     
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
-        
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -302,10 +293,8 @@ export class TopModelVIP extends Phaser.Scene {
 
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
-        
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+
+        stepMovementUpdates(this, delta);
     }
     
 }

--- a/client/scenes/Forest.js
+++ b/client/scenes/Forest.js
@@ -1,5 +1,5 @@
-import { setupMovement } from '../world/playerMovement.js';
-import { joinRoom, sendPlayerMove } from '../network/socket.js';
+import { stepMovementUpdates, setupMovement } from '../world/playerMovement.js';
+import { joinRoom } from '../network/socket.js';
 import { preloadAvatar, createAvatar } from '../world/avatar.js';
 import { initializePlayerManager } from '../world/playerManager.js';
 import { createRoomTransitionUI } from '../world/roomTransition.js';
@@ -57,9 +57,7 @@ export class Forest extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 }
 
@@ -102,9 +100,7 @@ export class Wizard extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -145,9 +141,7 @@ export class Grotto extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -195,9 +189,7 @@ export class GrottoSecretOne extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 }
 
@@ -243,9 +235,7 @@ export class GrottoSecretTwo extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 }
 
@@ -298,9 +288,7 @@ export class CreatureArea extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 }
 
@@ -339,9 +327,7 @@ export class CreatureShop extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }

--- a/client/scenes/Home.js
+++ b/client/scenes/Home.js
@@ -1,5 +1,5 @@
-import { setupMovement } from '../world/playerMovement.js';
-import { joinRoom, sendPlayerMove } from '../network/socket.js';
+import { stepMovementUpdates, setupMovement } from '../world/playerMovement.js';
+import { joinRoom } from '../network/socket.js';
 import { preloadAvatar, createAvatar} from '../world/avatar.js';
 import { initializePlayerManager } from '../world/playerManager.js';
 import { createMenu, preloadMenu } from '../world/UIManager.js';
@@ -42,9 +42,7 @@ export class Home extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }

--- a/client/scenes/Island.js
+++ b/client/scenes/Island.js
@@ -1,5 +1,5 @@
-import { setupMovement } from '../world/playerMovement.js';
-import { joinRoom, sendPlayerMove } from '../network/socket.js';
+import { stepMovementUpdates, setupMovement } from '../world/playerMovement.js';
+import { joinRoom } from '../network/socket.js';
 import { preloadAvatar, createAvatar } from '../world/avatar.js';
 import { initializePlayerManager } from '../world/playerManager.js';
 import { createRoomTransitionUI } from '../world/roomTransition.js';
@@ -57,9 +57,7 @@ export class Island extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 }
 
@@ -102,9 +100,7 @@ export class Spa extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -148,9 +144,7 @@ export class Resort extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -194,9 +188,7 @@ export class IslandStore extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }

--- a/client/scenes/Lighthouse.js
+++ b/client/scenes/Lighthouse.js
@@ -1,5 +1,5 @@
-import { setupMovement } from '../world/playerMovement.js';
-import { joinRoom, sendPlayerMove } from '../network/socket.js';
+import { stepMovementUpdates, setupMovement } from '../world/playerMovement.js';
+import { joinRoom } from '../network/socket.js';
 import { preloadAvatar, createAvatar } from '../world/avatar.js';
 import { initializePlayerManager } from '../world/playerManager.js';
 import { createRoomTransitionUI } from '../world/roomTransition.js';
@@ -53,9 +53,7 @@ export class Lighthouse extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
     
 }
@@ -96,9 +94,7 @@ export class LighthouseInside extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -145,9 +141,7 @@ export class LighthouseRoof extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
     
 }

--- a/client/scenes/Mountain.js
+++ b/client/scenes/Mountain.js
@@ -1,5 +1,5 @@
-import { setupMovement } from '../world/playerMovement.js';
-import { joinRoom, sendPlayerMove } from '../network/socket.js';
+import { stepMovementUpdates, setupMovement } from '../world/playerMovement.js';
+import { joinRoom } from '../network/socket.js';
 import { preloadAvatar, createAvatar } from '../world/avatar.js';
 import { initializePlayerManager } from '../world/playerManager.js';
 import { createRoomTransitionUI } from '../world/roomTransition.js';
@@ -54,9 +54,7 @@ export class Mountain extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 }
 
@@ -95,9 +93,7 @@ export class Cabin extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }

--- a/client/scenes/Oasis.js
+++ b/client/scenes/Oasis.js
@@ -1,5 +1,5 @@
-import { setupMovement } from '../world/playerMovement.js';
-import { joinRoom, sendPlayerMove } from '../network/socket.js';
+import { stepMovementUpdates, setupMovement } from '../world/playerMovement.js';
+import { joinRoom } from '../network/socket.js';
 import { preloadAvatar, createAvatar } from '../world/avatar.js';
 import { initializePlayerManager } from '../world/playerManager.js';
 import { createRoomTransitionUI } from '../world/roomTransition.js';
@@ -49,9 +49,7 @@ export class Oasis extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 }
 
@@ -91,9 +89,7 @@ export class Dock extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }

--- a/client/scenes/PetTown.js
+++ b/client/scenes/PetTown.js
@@ -1,5 +1,5 @@
-import { setupMovement } from '../world/playerMovement.js';
-import { joinRoom, sendPlayerMove } from '../network/socket.js';
+import { stepMovementUpdates, setupMovement } from '../world/playerMovement.js';
+import { joinRoom } from '../network/socket.js';
 import { preloadAvatar, createAvatar } from '../world/avatar.js';
 import { initializePlayerManager } from '../world/playerManager.js';
 import { createRoomTransitionUI } from '../world/roomTransition.js';
@@ -55,9 +55,7 @@ export class PetTown extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 }
 
@@ -95,9 +93,7 @@ export class PetShop extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -137,9 +133,7 @@ export class PetSchool extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -178,9 +172,7 @@ export class PetClass extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }

--- a/client/scenes/School.js
+++ b/client/scenes/School.js
@@ -1,5 +1,5 @@
-import { setupMovement } from '../world/playerMovement.js';
-import { joinRoom, sendPlayerMove } from '../network/socket.js';
+import { stepMovementUpdates, setupMovement } from '../world/playerMovement.js';
+import { joinRoom } from '../network/socket.js';
 import { preloadAvatar, createAvatar } from '../world/avatar.js';
 import { initializePlayerManager } from '../world/playerManager.js';
 import { createRoomTransitionUI } from '../world/roomTransition.js';
@@ -48,9 +48,7 @@ export class School extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
     
 }
@@ -98,9 +96,7 @@ export class SchoolInside extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
     
 }
@@ -140,9 +136,7 @@ export class MathRoom extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
     
 }
@@ -182,9 +176,7 @@ export class EnglishRoom extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
     
 }
@@ -227,9 +219,7 @@ export class SchoolUpstairs extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
     
 }
@@ -269,9 +259,7 @@ export class Cafeteria extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
     
 }
@@ -311,9 +299,7 @@ export class Gym extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
     
 }

--- a/client/scenes/Ship.js
+++ b/client/scenes/Ship.js
@@ -1,5 +1,5 @@
-import { setupMovement } from '../world/playerMovement.js';
-import { joinRoom, sendPlayerMove } from '../network/socket.js';
+import { stepMovementUpdates, setupMovement } from '../world/playerMovement.js';
+import { joinRoom } from '../network/socket.js';
 import { preloadAvatar, createAvatar } from '../world/avatar.js';
 import { initializePlayerManager } from '../world/playerManager.js';
 import { createRoomTransitionUI } from '../world/roomTransition.js';
@@ -54,9 +54,7 @@ export class Ship extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 }
 
@@ -107,8 +105,6 @@ export class Restaurant extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 }

--- a/client/scenes/Uptown.js
+++ b/client/scenes/Uptown.js
@@ -1,5 +1,5 @@
-import { setupMovement } from '../world/playerMovement.js';
-import { joinRoom, sendPlayerMove } from '../network/socket.js';
+import { stepMovementUpdates, setupMovement } from '../world/playerMovement.js';
+import { joinRoom } from '../network/socket.js';
 import { preloadAvatar, createAvatar } from '../world/avatar.js';
 import { initializePlayerManager } from '../world/playerManager.js';
 import { createRoomTransitionUI } from '../world/roomTransition.js';
@@ -61,9 +61,7 @@ export class Uptown extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 }
 
@@ -102,9 +100,7 @@ export class FurnitureShop extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -148,9 +144,7 @@ export class MyMall extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -194,9 +188,7 @@ export class IDfoneShop extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -240,9 +232,7 @@ export class Botique extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -282,9 +272,7 @@ export class CostumeShop extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -324,9 +312,7 @@ export class BoardShop extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 
 }
@@ -378,9 +364,7 @@ export class MissionCenter extends Phaser.Scene {
     update(time, delta) {
         if (this.updateMovement && this.room.connection.isOpen) this.updateMovement(delta);
         
-        if (this.room && this.player && this.room.connection.isOpen) {
-            sendPlayerMove(this.room, this.player.x, this.player.y, this.player.direction);
-        }
+        stepMovementUpdates(this, delta);
     }
 }
 

--- a/client/world/UIManager.js
+++ b/client/world/UIManager.js
@@ -2,6 +2,8 @@ import { mapTransition } from "./roomTransition.js";
 import { toggleEmotePopup } from "./animations.js";
 import { openInventory } from "./inventory.js";
 
+const BASE_DEPTH = 16535;
+
 export function createMenu(scene, player, room) {
   const { width, height } = scene.cameras.main;
 
@@ -18,7 +20,7 @@ export function createMenu(scene, player, room) {
   ];
 
   // Add the PNG as the background UI
-  const uiImage = scene.add.image(0, height, 'ui').setOrigin(0, 1).setScrollFactor(0);
+  const uiImage = scene.add.image(0, height, 'ui').setOrigin(0, 1).setScrollFactor(0).setDepth(BASE_DEPTH);
 
   // Add buttons using interactive rectangles over the specified areas
   buttonConfigs.forEach(({ name, x, y, screenX, screenY, boxWidth=39, boxHeight=37, callback }) => {
@@ -87,7 +89,7 @@ export function createMenu(scene, player, room) {
     24, // Height of the text box
     'rgba(82, 81, 77, 0.3)', // Semi-transparent yellow
     0.5 // Full opacity
-  ).setOrigin(0, 0).setInteractive().setScrollFactor(0);
+  ).setOrigin(0, 0).setInteractive().setScrollFactor(0).setDepth(BASE_DEPTH-2);
 
   inputBackground.on('pointerup', (pointer, localX, localY, event) => {
     event.stopPropagation();
@@ -100,7 +102,7 @@ export function createMenu(scene, player, room) {
     fontFamily: 'Arial',
     backgroundColor: 'rgba(82, 81, 77, 0.0)', // Semi-transparent yellow
     padding: { x: 8, y: 5 },
-  }).setOrigin(0, 0).setInteractive().setScrollFactor(0);
+  }).setOrigin(0, 0).setInteractive().setScrollFactor(0).setDepth(BASE_DEPTH-1);
   
   let isTyping = false;
   let fullText = ''; // The full input text
@@ -169,7 +171,7 @@ function openMapPopup(scene) {
 
   // Add the map image at the center of the screen
   const map = scene.add.image(mapX, mapY, 'map').setOrigin(0.5, 0.5).setScrollFactor(0).setInteractive();
-  map.setDepth(2);
+  map.setDepth(BASE_DEPTH);
   map.on('pointerup', (pointer, localX, localY, event) => {
     event.stopPropagation();
 });
@@ -205,7 +207,7 @@ function openMapPopup(scene) {
       .setInteractive()
       .setScrollFactor(0); // Fix to the camera view
 
-    button.setDepth(2)
+    button.setDepth(BASE_DEPTH)
 
       // Add pointerdown event
     button.on('pointerdown', (pointer, localX, localY, event) => {
@@ -303,8 +305,8 @@ export function displayChatBubble(scene, player, message) {
   const updateBubblePosition = () => {
     bubbleContainer.setPosition(player.x, player.y - 130);
     bubble.setPosition(player.x, player.y - 140);
-    bubble.setDepth(1); // Ensure text is rendered above the graphics
-    bubbleContainer.setDepth(0); // Ensure graphics are below the text
+    bubble.setDepth(player.depth+1); // Ensure text is rendered above the graphics
+    bubbleContainer.setDepth(player.depth); // Ensure graphics are below the text
   };
   scene.events.on('update', updateBubblePosition);
 

--- a/client/world/animations.js
+++ b/client/world/animations.js
@@ -94,7 +94,7 @@ export function toggleEmotePopup(scene, player, room) {
             .setInteractive()
             .setScrollFactor(0); // Fix to the camera view
         
-            button.setDepth(2)
+            button.setDepth(BASE_DEPTH)
         
             // Add pointerdown event
             button.on('pointerdown', (pointer, x, y, event) => {

--- a/client/world/animations.js
+++ b/client/world/animations.js
@@ -1,5 +1,7 @@
 import { assets } from "../assets/data.js";
 
+const BASE_DEPTH = 16535;
+
 export function createAvatarAnimations(scene, player) {
     // Function to create animations dynamically per player
     function createAnimation(key, texture, frames, frameRate = 2.5) {
@@ -70,8 +72,7 @@ export function toggleEmotePopup(scene, player, room) {
            
     } else {
         // Create the popup image
-        emotePopup = scene.add.image(257, 376, 'actionmenu').setOrigin(0.5, 0.5).setScrollFactor(0);
-        emotePopup.setDepth(2); // Ensure it's above other UI elements
+        emotePopup = scene.add.image(257, 376, 'actionmenu').setOrigin(0.5, 0.5).setScrollFactor(0).setDepth(BASE_DEPTH);
 
         const buttonConfigs = [
             { name: 'wave', x: 238, y: 301, width: 30, height: 30 },

--- a/client/world/inventory.js
+++ b/client/world/inventory.js
@@ -2,9 +2,11 @@ import { assets, tops, bottoms, shoes, boards } from '../assets/data.js';
 import { createAvatarAnimations, performIdles } from './animations.js';
 import { getPlayerAvatarData, updateLocalAvatarData } from "../game.js";
 
+const BASE_DEPTH = 16535;
+
 export function openInventory(scene, player, room){
     //const { width, height } = scene.cameras.main;
-    const inventory = scene.add.image(0, 0, 'inventorybg').setOrigin(0, 0).setScrollFactor(0).setInteractive().setDepth(2);
+    const inventory = scene.add.image(0, 0, 'inventorybg').setOrigin(0, 0).setScrollFactor(0).setInteractive().setDepth(BASE_DEPTH+2);
 
     // Store initial outfit for comparison
     const initialAvatarData = { 
@@ -20,7 +22,7 @@ export function openInventory(scene, player, room){
     });
 
     // Create closet avatar
-    const previewPlayer = scene.add.container(694, 350).setDepth(2).setScrollFactor(0);
+    const previewPlayer = scene.add.container(694, 350).setDepth(BASE_DEPTH+2).setScrollFactor(0);
 
     let previewParts = [];
     let previewHair = null; // Store hair separately
@@ -35,7 +37,7 @@ export function openInventory(scene, player, room){
             let clonedPart = scene.add.image(part.x, part.y, part.texture.key)
                 .setOrigin(part.originX, part.originY)
                 .setScale(part.scaleX, part.scaleY)
-                .setDepth(3);
+                .setDepth(BASE_DEPTH+3);
             if (clonedPart) {
                 previewParts.push(clonedPart);
                 previewPlayer.add(clonedPart);
@@ -63,7 +65,7 @@ export function openInventory(scene, player, room){
     previewPlayer.board = previewBoard;
     
     // Create a close button
-    const closeInventory = scene.add.ellipse(778, 21, 30, 30, 0xffffff, 0).setInteractive().setScrollFactor(0).setDepth(2);
+    const closeInventory = scene.add.ellipse(778, 21, 30, 30, 0xffffff, 0).setInteractive().setScrollFactor(0).setDepth(BASE_DEPTH+2);
 
     closeInventory.on('pointerup', async (pointer, localX, localY, event) => {
         // Save hair
@@ -171,7 +173,7 @@ export function openInventory(scene, player, room){
     });
 
     // Create switch to hairs button
-    const switchToHairs = scene.add.rectangle(46, 73, 72, 29, 0xffffff, 0).setInteractive().setScrollFactor(0).setDepth(2).setOrigin(0.5, 0.5);
+    const switchToHairs = scene.add.rectangle(46, 73, 72, 29, 0xffffff, 0).setInteractive().setScrollFactor(0).setDepth(BASE_DEPTH+2).setOrigin(0.5, 0.5);
 
     switchToHairs.on('pointerup', (pointer, localX, localY, event) => {
         event.stopPropagation(); 
@@ -196,7 +198,7 @@ export function openInventory(scene, player, room){
     });
 
     // Create switch to tops button
-    const switchToClothes = scene.add.rectangle(139, 73, 104, 28, 0xffffff, 0).setInteractive().setScrollFactor(0).setDepth(2).setOrigin(0.5, 0.5);
+    const switchToClothes = scene.add.rectangle(139, 73, 104, 28, 0xffffff, 0).setInteractive().setScrollFactor(0).setDepth(BASE_DEPTH+2).setOrigin(0.5, 0.5);
 
     switchToClothes.on('pointerup', (pointer, localX, localY, event) => {
         event.stopPropagation(); 
@@ -220,12 +222,12 @@ export function openInventory(scene, player, room){
         switchToClothes.setFillStyle(0xffffff, 0); // Remove highlight
     });
 
-    const switchToTops = scene.add.rectangle(98, 97, 33, 15, 0xffffff, 0).setInteractive().setScrollFactor(0).setDepth(3).setOrigin(0.5, 0.5).setVisible(false);
-    const switchToBottoms = scene.add.rectangle(165, 97, 60, 15, 0xffffff, 0).setInteractive().setScrollFactor(0).setDepth(3).setOrigin(0.5, 0.5).setVisible(false);
+    const switchToTops = scene.add.rectangle(98, 97, 33, 15, 0xffffff, 0).setInteractive().setScrollFactor(0).setDepth(BASE_DEPTH+3).setOrigin(0.5, 0.5).setVisible(false);
+    const switchToBottoms = scene.add.rectangle(165, 97, 60, 15, 0xffffff, 0).setInteractive().setScrollFactor(0).setDepth(BASE_DEPTH+3).setOrigin(0.5, 0.5).setVisible(false);
     
-    //const switchToOutfits = scene.add.rectangle(244, 97, 55, 15, 0xffffff, 0).setInteractive().setScrollFactor(0).setDepth(3).setOrigin(0.5, 0.5).setVisible(false);
-    //const switchToCostumes = scene.add.rectangle(331, 97, 70, 15, 0xffffff, 0).setInteractive().setScrollFactor(0).setDepth(3).setOrigin(0.5, 0.5).setVisible(false);
-    const switchToShoes = scene.add.rectangle(413, 97, 45, 15, 0xffffff, 0).setInteractive().setScrollFactor(0).setDepth(3).setOrigin(0.5, 0.5).setVisible(false);
+    //const switchToOutfits = scene.add.rectangle(244, 97, 55, 15, 0xffffff, 0).setInteractive().setScrollFactor(0).setDepth(BASE_DEPTH+3).setOrigin(0.5, 0.5).setVisible(false);
+    //const switchToCostumes = scene.add.rectangle(331, 97, 70, 15, 0xffffff, 0).setInteractive().setScrollFactor(0).setDepth(BASE_DEPTH+3).setOrigin(0.5, 0.5).setVisible(false);
+    const switchToShoes = scene.add.rectangle(413, 97, 45, 15, 0xffffff, 0).setInteractive().setScrollFactor(0).setDepth(BASE_DEPTH+3).setOrigin(0.5, 0.5).setVisible(false);
     
     switchToTops.on('pointerup', (pointer, localX, localY, event) => {
         event.stopPropagation(); 
@@ -279,7 +281,7 @@ export function openInventory(scene, player, room){
     });
 
 
-    const switchToBoards = scene.add.rectangle(235, 73, 90, 28, 0xffffff, 0).setInteractive().setScrollFactor(0).setDepth(2).setOrigin(0.5, 0.5);
+    const switchToBoards = scene.add.rectangle(235, 73, 90, 28, 0xffffff, 0).setInteractive().setScrollFactor(0).setDepth(BASE_DEPTH+2).setOrigin(0.5, 0.5);
     switchToBoards.on('pointerup', (pointer, localX, localY, event) => {
         event.stopPropagation(); 
         if (currentPage != "boards"){
@@ -305,7 +307,7 @@ export function openInventory(scene, player, room){
     // Start inventory at hairs
     let clothingSelection = new HairSelection(scene, player, previewPlayer);
     let currentPage = "hair";
-    let sideBar = scene.add.image(400, 96, 'clothSelectionSideBar').setOrigin(0.5, 0.5).setScrollFactor(0).setDepth(2).setVisible(false);
+    let sideBar = scene.add.image(400, 96, 'clothSelectionSideBar').setOrigin(0.5, 0.5).setScrollFactor(0).setDepth(BASE_DEPTH+2).setVisible(false);
 }
 
 class HairSelection {
@@ -342,7 +344,7 @@ class HairSelection {
                 var hairSprite = this.scene.add.sprite(x+5, y, hairKey, 0).setInteractive().setScrollFactor(0).setScale(.8, .8);
             }
             this.container.add(hairSprite);
-            this.container.setDepth(2);
+            this.container.setDepth(BASE_DEPTH+2);
 
             // Arrange in rows and columns
             x += spacingX;
@@ -372,7 +374,7 @@ class HairSelection {
             .on('pointerup', (pointer, localX, localY, event) => {
                 event.stopPropagation();
             })
-            .setDepth(2);
+            .setDepth(BASE_DEPTH+2);
     
         // Previous Page Button (Up Arrow)
         this.prevButton = this.scene.add.text(546, 154, '▲', { fontSize: '32px', fill: '#fff' })
@@ -383,7 +385,7 @@ class HairSelection {
             .on('pointerup', (pointer, localX, localY, event) => {
                 event.stopPropagation();
             })
-            .setDepth(2);
+            .setDepth(BASE_DEPTH+2);
     
         this.scene.add.existing(this.nextButton);
         this.scene.add.existing(this.prevButton);
@@ -467,7 +469,7 @@ class TopSelection {
                 var topSprite = this.scene.add.sprite(x, y, topKey, 0).setInteractive().setScrollFactor(0).setScale(1, 1);
             }
             this.container.add(topSprite);
-            this.container.setDepth(2);
+            this.container.setDepth(BASE_DEPTH+2);
 
             // Arrange in rows and columns
             x += spacingX;
@@ -497,7 +499,7 @@ class TopSelection {
             .on('pointerup', (pointer, localX, localY, event) => {
                 event.stopPropagation();
             })
-            .setDepth(2);
+            .setDepth(BASE_DEPTH+2);
     
         // Previous Page Button (Up Arrow)
         this.prevButton = this.scene.add.text(546, 154, '▲', { fontSize: '32px', fill: '#fff' })
@@ -508,7 +510,7 @@ class TopSelection {
             .on('pointerup', (pointer, localX, localY, event) => {
                 event.stopPropagation();
             })
-            .setDepth(2);
+            .setDepth(BASE_DEPTH+2);
     
         this.scene.add.existing(this.nextButton);
         this.scene.add.existing(this.prevButton);
@@ -602,7 +604,7 @@ class BottomSelection {
             }
 
             this.container.add(bottomSprite);
-            this.container.setDepth(2);
+            this.container.setDepth(BASE_DEPTH+2);
 
             // Arrange in rows and columns
             x += spacingX;
@@ -632,7 +634,7 @@ class BottomSelection {
             .on('pointerup', (pointer, localX, localY, event) => {
                 event.stopPropagation();
             })
-            .setDepth(2);
+            .setDepth(BASE_DEPTH+2);
     
         // Previous Page Button (Up Arrow)
         this.prevButton = this.scene.add.text(546, 154, '▲', { fontSize: '32px', fill: '#fff' })
@@ -643,7 +645,7 @@ class BottomSelection {
             .on('pointerup', (pointer, localX, localY, event) => {
                 event.stopPropagation();
             })
-            .setDepth(2);
+            .setDepth(BASE_DEPTH+2);
     
         this.scene.add.existing(this.nextButton);
         this.scene.add.existing(this.prevButton);
@@ -733,7 +735,7 @@ class ShoeSelection {
             }
 
             this.container.add(shoeSprite);
-            this.container.setDepth(2);
+            this.container.setDepth(BASE_DEPTH+2);
 
             // Arrange in rows and columns
             x += spacingX;
@@ -763,7 +765,7 @@ class ShoeSelection {
             .on('pointerup', (pointer, localX, localY, event) => {
                 event.stopPropagation();
             })
-            .setDepth(2);
+            .setDepth(BASE_DEPTH+2);
     
         // Previous Page Button (Up Arrow)
         this.prevButton = this.scene.add.text(546, 154, '▲', { fontSize: '32px', fill: '#fff' })
@@ -774,7 +776,7 @@ class ShoeSelection {
             .on('pointerup', (pointer, localX, localY, event) => {
                 event.stopPropagation();
             })
-            .setDepth(2);
+            .setDepth(BASE_DEPTH+2);
     
         this.scene.add.existing(this.nextButton);
         this.scene.add.existing(this.prevButton);
@@ -853,7 +855,7 @@ class BoardSelection {
                 var hairSprite = this.scene.add.image(x, y, hairKey).setInteractive().setScrollFactor(0);
             }
             this.container.add(hairSprite);
-            this.container.setDepth(2);
+            this.container.setDepth(BASE_DEPTH+2);
 
             // Arrange in rows and columns
             x += spacingX;
@@ -883,7 +885,7 @@ class BoardSelection {
             .on('pointerup', (pointer, localX, localY, event) => {
                 event.stopPropagation();
             })
-            .setDepth(2);
+            .setDepth(BASE_DEPTH+2);
     
         // Previous Page Button (Up Arrow)
         this.prevButton = this.scene.add.text(546, 154, '▲', { fontSize: '32px', fill: '#fff' })
@@ -894,7 +896,7 @@ class BoardSelection {
             .on('pointerup', (pointer, localX, localY, event) => {
                 event.stopPropagation();
             })
-            .setDepth(2);
+            .setDepth(BASE_DEPTH+2);
     
         this.scene.add.existing(this.nextButton);
         this.scene.add.existing(this.prevButton);

--- a/client/world/playerManager.js
+++ b/client/world/playerManager.js
@@ -80,6 +80,7 @@ export function initializePlayerManager(scene) {
             const otherPlayer = avatar;
             //otherPlayer.room = room; // Track the player's room
             otherPlayer.setPosition(playerData.x, playerData.y);
+            otherPlayer.depth = otherPlayer.y;
             scene.otherPlayers[id] = otherPlayer;
             createAvatarAnimations(scene, otherPlayer);
             performIdles(otherPlayer);

--- a/client/world/playerManager.js
+++ b/client/world/playerManager.js
@@ -3,6 +3,7 @@ import { createAvatarAnimations, performIdles } from './animations.js';
 
 export function initializePlayerManager(scene) {
     scene.otherPlayers = {}; // Store other players
+    scene.playersTargetPosition = {}; // Store click positions of players to lerp movement.
 
     scene.addOtherPlayer = (id, playerData, direction) => {
         if (!scene.otherPlayers[id]) {
@@ -78,6 +79,7 @@ export function initializePlayerManager(scene) {
             
             const otherPlayer = avatar;
             //otherPlayer.room = room; // Track the player's room
+            otherPlayer.setPosition(playerData.x, playerData.y);
             scene.otherPlayers[id] = otherPlayer;
             createAvatarAnimations(scene, otherPlayer);
             performIdles(otherPlayer);
@@ -87,8 +89,9 @@ export function initializePlayerManager(scene) {
     // Update an existing player's position
     scene.updateOtherPlayer = (id, x, y, direction) => {
         if (scene.otherPlayers[id]) {
+            scene.playersTargetPosition[id] = {x, y};
             const otherPlayer = scene.otherPlayers[id];
-            otherPlayer.setPosition(x, y);
+            //console.log("Other player to coords: "+x+", "+y+" from "+otherPlayer.x+", "+otherPlayer.y);
     
             // Update facing direction
             if (direction === 'left') {

--- a/client/world/playerMovement.js
+++ b/client/world/playerMovement.js
@@ -11,7 +11,13 @@ export function setupMovement(scene) {
         if (player.isJumping || player.isCrying) return;
         scene.playersTargetPosition[scene.room.sessionId] = { x: pointer.worldX, y: pointer.worldY }; // Store target position
         if (scene.room) {
-            scene.room.send('move', { x: pointer.worldX, y: pointer.worldY, direction: player.direction}); //direction: player.base.getData('direction') 
+            // Determine direction initially. Quick n dirty fix but *shrug*
+            const targetPosition = scene.playersTargetPosition[scene.room.sessionId];
+            const angle = Phaser.Math.Angle.Between(player.x, player.y, targetPosition.x, targetPosition.y);
+            const velocityX = Math.cos(angle);
+            const direction = velocityX > 0 ? 'right' : 'left';
+
+            scene.room.send('move', { x: pointer.worldX, y: pointer.worldY, direction}); //direction: player.base.getData('direction') 
         }
     });
 }

--- a/client/world/playerMovement.js
+++ b/client/world/playerMovement.js
@@ -80,7 +80,8 @@ function lerpMovement(scene, id, player, targetPosition, delta) {
 
             player.x += velocityX;
             player.y += velocityY;
-
+            player.depth = player.y;
+            // We set the z to the y for z-layer ordering
             
         }
     }

--- a/client/world/playerMovement.js
+++ b/client/world/playerMovement.js
@@ -1,52 +1,82 @@
-export function setupMovement(scene, player, moveSpeed) {
-    let targetPosition = null;
-    moveSpeed = 250
-    // Handle click-to-move
+/**
+ * The click handler for movement in a room.
+ * 
+ * @param {*} scene Target scene
+ */
+export function setupMovement(scene) {
+    let player = scene.player;
+    
     scene.input.on('pointerup', (pointer) => {
         if (pointer.event.defaultPrevented) return;
         if (player.isJumping || player.isCrying) return;
-        targetPosition = { x: pointer.worldX, y: pointer.worldY }; // Store target position
-    });
-
-    // Return the `update` function to manage smooth movement
-    return (delta) => {
-        if (targetPosition) {
-            // Calculate distance to the target
-            const distance = Phaser.Math.Distance.Between(player.x, player.y, targetPosition.x, targetPosition.y);
-
-            if (distance < 4) {
-                // Stop moving when close enough
-                player.setPosition(targetPosition.x, targetPosition.y);
-                targetPosition = null;
-            } else {
-                // Calculate angle and move the player
-                const angle = Phaser.Math.Angle.Between(player.x, player.y, targetPosition.x, targetPosition.y);
-                const velocityX = Math.cos(angle) * (moveSpeed * (delta / 1000));
-                const velocityY = Math.sin(angle) * (moveSpeed * (delta / 1000));
-
-                // Flip the avatar container based on movement direction
-                if (velocityX > 0 && player.base.getData('direction') !== 'right') {
-                    // Moving right: flip to face right
-                    player.setScale(-1, 1);
-                    // Keep name tag facing the same direction
-                    player.nameTag.setScale(-1, 1);
-                    player.base.setData('direction', 'right');
-                    player.direction = 'right';
-                } else if (velocityX < 0 && player.base.getData('direction') !== 'left') {
-                    // Moving left: keep the initial left-facing direction
-                    player.setScale(1, 1);
-                    player.nameTag.setScale(1, 1);
-                    player.base.setData('direction', 'left');
-                    player.direction = 'left';
-                }
-
-                player.x += velocityX;
-                player.y += velocityY;
-
-                if (scene.room) {
-                    scene.room.send('move', { x: player.x, y: player.y, direction: player.direction}); //direction: player.base.getData('direction') 
-                }
-            }
+        scene.playersTargetPosition[scene.room.sessionId] = { x: pointer.worldX, y: pointer.worldY }; // Store target position
+        if (scene.room) {
+            scene.room.send('move', { x: pointer.worldX, y: pointer.worldY, direction: player.direction}); //direction: player.base.getData('direction') 
         }
-    };
+    });
+}
+
+/**
+ * A function that goes through the list of players actively moving and updates their position.
+ * When the player reaches the target position, they get removed from the update array.
+ * 
+ * @param {*} scene Target scene 
+ * @param {*} delta Delta time 
+ */
+export function stepMovementUpdates(scene, delta) {
+    if (scene.room && scene.player && scene.room.connection.isOpen) {
+        // If local player is in a valid room, cycle through updates and lerp the position.
+        for(var id in scene.playersTargetPosition) {
+            let curPlayer = scene.room.sessionId == id ? scene.player : scene.otherPlayers[id];
+            lerpMovement(scene, id, curPlayer, scene.playersTargetPosition[id], delta);
+        }
+    }
+}
+
+// The function that lerps the player's current position to the target position.
+function lerpMovement(scene, id, player, targetPosition, delta) {
+    let moveSpeed = 250;
+    
+    if (targetPosition) {
+        if(player == null) {
+            scene.playersTargetPosition[id] = null;
+            return;
+        }
+
+        // Calculate distance to the target
+        const distance = Phaser.Math.Distance.Between(player.x, player.y, targetPosition.x, targetPosition.y);
+
+        if (distance < 4) {
+            // Stop moving when close enough
+            player.setPosition(targetPosition.x, targetPosition.y);
+            scene.playersTargetPosition[id] = null;
+        } else {
+            // Calculate angle and move the player
+            const angle = Phaser.Math.Angle.Between(player.x, player.y, targetPosition.x, targetPosition.y);
+            const velocityX = Math.cos(angle) * (moveSpeed * (delta / 1000));
+            const velocityY = Math.sin(angle) * (moveSpeed * (delta / 1000));
+
+            // Flip the avatar container based on movement direction
+            if (velocityX > 0 && player.base.getData('direction') !== 'right') {
+                // Moving right: flip to face right
+                player.setScale(-1, 1);
+                // Keep name tag facing the same direction
+                player.nameTag.setScale(-1, 1);
+                player.base.setData('direction', 'right');
+                player.direction = 'right';
+            } else if (velocityX < 0 && player.base.getData('direction') !== 'left') {
+                // Moving left: keep the initial left-facing direction
+                player.setScale(1, 1);
+                player.nameTag.setScale(1, 1);
+                player.base.setData('direction', 'left');
+                player.direction = 'left';
+            }
+
+            player.x += velocityX;
+            player.y += velocityY;
+
+            
+        }
+    }
+    
 }

--- a/server/rooms/GameRoom.ts
+++ b/server/rooms/GameRoom.ts
@@ -10,22 +10,24 @@ export class GameRoom extends Room<RoomState> {
         this.onMessage('move', (client: Client, data: { x: number; y: number; direction: string }) => {
             const player = this.state.players.get(client.sessionId);
             if (player) {
+                //TODO: update so it tracks player lerping. Not a high priority for now.
                 player.x = data.x;
                 player.y = data.y;
                 player.direction = data.direction;
 
                 // Broadcast movement updates only to players in the same room
                 this.broadcastToRoom(player.room, 'playerMoved', { id: client.sessionId, x: player.x, y: player.y, direction: player.direction }, client);
+                //console.log("Player movement detected, new coords x: "+player.x+", y: "+player.y)
             }
         });
 
         this.onMessage("chat", (client, message) => {
             console.log(`Received chat message from ${client.sessionId}: ${message.message}`);
-      
+    
             // Broadcast the chat message to all players in the room
             this.broadcast("chat", {
-              id: client.sessionId,
-              message: message.message,
+                id: client.sessionId,
+                message: message.message,
             });
         });
 
@@ -74,6 +76,9 @@ export class GameRoom extends Room<RoomState> {
     onJoin(client: Client, options: any): void {
         const newPlayer = new PlayerState(options);
         newPlayer.room = options.roomName || 'default'; // Assign the room from options or default
+        newPlayer.x = options.x;
+        newPlayer.y = options.y;
+        newPlayer.direction = options.playerDirection;
         this.state.players.set(client.sessionId, newPlayer);
 
         console.log(`Player ${client.sessionId} joined room: ${newPlayer.room}`);
@@ -85,7 +90,6 @@ export class GameRoom extends Room<RoomState> {
                 ...player
         }));
         
-
         client.send('currentPlayers', playersInRoom);
 
         // Notify other players in the same room about the new player


### PR DESCRIPTION
Movement constantly spammed packets every update which uses up a huge amount of bandwidth. This PR changes it so it updates movement per click and lerps between current position and target position.

Known issues:
- The server stores the target position immediately. This isn't really a huge deal at the moment as the server is just used for synchronization.
- When joining a room, the player may be facing the wrong direction. This is immediately fixed if they move at all. No idea what really causes this, but this isn't something that's major.