### PR TITLE
Enforce using env file for sensitive data

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DB_URL="DB URL HERE"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /node_modules
+server/firebase/firebaseServiceAccount.json
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 server/firebase/firebaseServiceAccount.json
 .env
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "colyseus.js": "^0.16.2",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
-    "dotenv": "^16.4.7",
+    "dotenv": "^16.5.0",
     "express": "^4.21.2",
     "firebase": "^11.3.0",
     "firebase-admin": "^13.1.0",

--- a/server/firebase/firebaseAdmin.js
+++ b/server/firebase/firebaseAdmin.js
@@ -7,7 +7,7 @@ dotenv.config();
 // ✅ Initialize Firebase Admin SDK
 admin.initializeApp({
     credential: admin.credential.cert(serviceAccount),
-    databaseURL: "", // This should match your Firebase Realtime Database URL
+    databaseURL: process.env.DB_URL, // This should match your Firebase Realtime Database URL
 });
 
 const db = admin.database();


### PR DESCRIPTION
This is considered good practice. Instead of having people put the url straight inside of the js file, we should put it in an env file.

This also updates the gitignore so people dont accidentally push sensitive info or node modules