### PR TITLE
refactor: pass scene to idle animation helper

### DIFF
--- a/client/network/socket.js
+++ b/client/network/socket.js
@@ -213,7 +213,7 @@ export async function joinRoom(scene, roomName) {
 
                 // Create animations for the new avatar
                 createAvatarAnimations(scene, otherPlayer);
-                performIdles(otherPlayer);
+                performIdles(scene, otherPlayer);
             }
         });
 
@@ -252,7 +252,7 @@ export async function joinRoom(scene, roomName) {
 
                 // Create animations for the new avatar
                 createAvatarAnimations(scene, otherPlayer);
-                performIdles(otherPlayer);
+                performIdles(scene, otherPlayer);
             }
         });
         

--- a/client/scenes/Beach.js
+++ b/client/scenes/Beach.js
@@ -32,7 +32,7 @@ export class Beach extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         this.cameras.main.startFollow(this.player);
 
         initializePlayerManager(this);
@@ -84,7 +84,7 @@ export class DanceClub extends Phaser.Scene {
         this.add.image(0, 0, 'danceclub').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'danceclub'); 
@@ -130,7 +130,7 @@ export class TanStore extends Phaser.Scene {
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
         createAvatarAnimations(this, this.player);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'tanstore'); 

--- a/client/scenes/Carnival.js
+++ b/client/scenes/Carnival.js
@@ -30,7 +30,7 @@ export class Carnival extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         this.cameras.main.startFollow(this.player);
 
         initializePlayerManager(this);
@@ -79,7 +79,7 @@ export class Arcade extends Phaser.Scene {
         this.add.image(0, 0, 'arcade').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'arcade'); 

--- a/client/scenes/Castle.js
+++ b/client/scenes/Castle.js
@@ -35,7 +35,7 @@ export class Castle extends Phaser.Scene {
         this.add.image(0, 0, 'castle').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'castle');
@@ -88,7 +88,7 @@ export class CastleYard extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         this.cameras.main.startFollow(this.player);
 
         initializePlayerManager(this);
@@ -144,7 +144,7 @@ export class CastleInside extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         this.cameras.main.startFollow(this.player);
 
         initializePlayerManager(this);

--- a/client/scenes/Downtown.js
+++ b/client/scenes/Downtown.js
@@ -40,7 +40,7 @@ export class Downtown extends Phaser.Scene {
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
         
         createAvatarAnimations(this, this.player);
-        performIdles(this.player);
+        performIdles(this, this.player);
 
         this.cameras.main.startFollow(this.player);
 
@@ -98,7 +98,7 @@ export class StarCafe extends Phaser.Scene {
         this.add.image(0, 0, 'starcafe').setOrigin(0, 0);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'starcafe'); 
@@ -142,7 +142,7 @@ export class LeShop extends Phaser.Scene {
         this.add.image(0, 0, 'leshop').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'leshop'); 
@@ -183,7 +183,7 @@ export class Salon extends Phaser.Scene {
         this.add.image(0, 0, 'salon').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'salon'); 
@@ -224,7 +224,7 @@ export class TopModel extends Phaser.Scene {
         this.add.image(0, 0, 'topmodel').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'topmodel'); 
@@ -272,7 +272,7 @@ export class TopModelVIP extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         this.cameras.main.startFollow(this.player);
 
         initializePlayerManager(this);

--- a/client/scenes/Forest.js
+++ b/client/scenes/Forest.js
@@ -30,7 +30,7 @@ export class Forest extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         this.cameras.main.startFollow(this.player);
 
         initializePlayerManager(this);
@@ -82,7 +82,7 @@ export class Wizard extends Phaser.Scene {
         this.add.image(0, 0, 'wizard').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'wizard'); 
@@ -125,7 +125,7 @@ export class Grotto extends Phaser.Scene {
         this.add.image(0, 0, 'grotto').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'grotto'); 
@@ -169,7 +169,7 @@ export class GrottoSecretOne extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         this.cameras.main.startFollow(this.player);
 
         initializePlayerManager(this);
@@ -216,7 +216,7 @@ export class GrottoSecretTwo extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         this.cameras.main.startFollow(this.player);
 
         initializePlayerManager(this);
@@ -263,7 +263,7 @@ export class CreatureArea extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         this.cameras.main.startFollow(this.player);
 
         initializePlayerManager(this);
@@ -312,7 +312,7 @@ export class CreatureShop extends Phaser.Scene {
         this.add.image(0, 0, 'creatureshop').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'creatureshop'); 

--- a/client/scenes/Home.js
+++ b/client/scenes/Home.js
@@ -28,7 +28,7 @@ export class Home extends Phaser.Scene {
         this.add.image(0, 0, 'default_home1').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'home'); 

--- a/client/scenes/Island.js
+++ b/client/scenes/Island.js
@@ -30,7 +30,7 @@ export class Island extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         this.cameras.main.startFollow(this.player);
 
         initializePlayerManager(this);
@@ -82,7 +82,7 @@ export class Spa extends Phaser.Scene {
         this.add.image(0, 0, 'spa').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'spa'); 
@@ -126,7 +126,7 @@ export class Resort extends Phaser.Scene {
         this.add.image(0, 0, 'resort').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'resort'); 
@@ -170,7 +170,7 @@ export class IslandStore extends Phaser.Scene {
         this.add.image(0, 0, 'islandstore').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'islandstore'); 

--- a/client/scenes/Lighthouse.js
+++ b/client/scenes/Lighthouse.js
@@ -30,7 +30,7 @@ export class Lighthouse extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         this.cameras.main.startFollow(this.player);
 
         initializePlayerManager(this);
@@ -78,7 +78,7 @@ export class LighthouseInside extends Phaser.Scene {
         this.add.image(0, 0, 'lighthouse_inside').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'lighthouse_inside'); 
@@ -122,7 +122,7 @@ export class LighthouseRoof extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         this.cameras.main.startFollow(this.player);
 
         initializePlayerManager(this);

--- a/client/scenes/Mountain.js
+++ b/client/scenes/Mountain.js
@@ -30,7 +30,7 @@ export class Mountain extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         this.cameras.main.startFollow(this.player);
 
         initializePlayerManager(this);
@@ -78,7 +78,7 @@ export class Cabin extends Phaser.Scene {
         this.add.image(0, 0, 'cabin').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'cabin'); 

--- a/client/scenes/Oasis.js
+++ b/client/scenes/Oasis.js
@@ -30,7 +30,7 @@ export class Oasis extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         this.cameras.main.startFollow(this.player);
 
         initializePlayerManager(this);
@@ -74,7 +74,7 @@ export class Dock extends Phaser.Scene {
         this.add.image(0, 0, 'dock').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'dock'); 

--- a/client/scenes/PetTown.js
+++ b/client/scenes/PetTown.js
@@ -30,7 +30,7 @@ export class PetTown extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         this.cameras.main.startFollow(this.player);
 
         initializePlayerManager(this);
@@ -79,7 +79,7 @@ export class PetShop extends Phaser.Scene {
         this.add.image(0, 0, 'petshop').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'petshop');
@@ -118,7 +118,7 @@ export class PetSchool extends Phaser.Scene {
         this.add.image(0, 0, 'petschool').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'petschool');
@@ -158,7 +158,7 @@ export class PetClass extends Phaser.Scene {
         this.add.image(0, 0, 'petclass').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'petclass');

--- a/client/scenes/School.js
+++ b/client/scenes/School.js
@@ -27,7 +27,7 @@ export class School extends Phaser.Scene {
         this.add.image(0, 0, 'school_outside').setOrigin(0, 0);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this); // Initialize multiplayer logic for this scene
         
         // Join the networked room
@@ -74,7 +74,7 @@ export class SchoolInside extends Phaser.Scene {
         this.add.image(0, 0, 'school_inside').setOrigin(0, 0);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this); // Initialize multiplayer logic for this scene
         
         // Join the networked room
@@ -121,7 +121,7 @@ export class MathRoom extends Phaser.Scene {
         this.add.image(0, 0, 'mathroom').setOrigin(0, 0);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this); // Initialize multiplayer logic for this scene
         
         // Join the networked room
@@ -161,7 +161,7 @@ export class EnglishRoom extends Phaser.Scene {
         this.add.image(0, 0, 'englishroom').setOrigin(0, 0);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this); // Initialize multiplayer logic for this scene
         
         // Join the networked room
@@ -201,7 +201,7 @@ export class SchoolUpstairs extends Phaser.Scene {
         this.add.image(0, 0, 'school_upstairs').setOrigin(0, 0);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this); // Initialize multiplayer logic for this scene
         
         // Join the networked room
@@ -244,7 +244,7 @@ export class Cafeteria extends Phaser.Scene {
         this.add.image(0, 0, 'cafeteria').setOrigin(0, 0);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this); // Initialize multiplayer logic for this scene
         
         // Join the networked room
@@ -284,7 +284,7 @@ export class Gym extends Phaser.Scene {
         this.add.image(0, 0, 'gym').setOrigin(0, 0);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this); // Initialize multiplayer logic for this scene
         
         // Join the networked room

--- a/client/scenes/Ship.js
+++ b/client/scenes/Ship.js
@@ -30,7 +30,7 @@ export class Ship extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         this.cameras.main.startFollow(this.player);
 
         initializePlayerManager(this);
@@ -82,7 +82,7 @@ export class Restaurant extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
 
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         this.cameras.main.startFollow(this.player);
 
         initializePlayerManager(this);

--- a/client/scenes/Uptown.js
+++ b/client/scenes/Uptown.js
@@ -30,7 +30,7 @@ export class Uptown extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         this.cameras.main.startFollow(this.player);
 
         initializePlayerManager(this);
@@ -85,7 +85,7 @@ export class FurnitureShop extends Phaser.Scene {
         this.add.image(0, 0, 'furnitureshop').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'furnitureshop'); 
@@ -126,7 +126,7 @@ export class MyMall extends Phaser.Scene {
         this.add.image(0, 0, 'mymall').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'mymall'); 
@@ -170,7 +170,7 @@ export class IDfoneShop extends Phaser.Scene {
         this.add.image(0, 0, 'idfoneshop').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'idfoneshop'); 
@@ -214,7 +214,7 @@ export class Botique extends Phaser.Scene {
         this.add.image(0, 0, 'botique').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'botique'); 
@@ -257,7 +257,7 @@ export class CostumeShop extends Phaser.Scene {
         this.add.image(0, 0, 'costumeshop').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'costumeshop'); 
@@ -297,7 +297,7 @@ export class BoardShop extends Phaser.Scene {
         this.add.image(0, 0, 'boardshop').setOrigin(0, 0);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         initializePlayerManager(this);
 
         this.room = await joinRoom(this, 'boardshop'); 
@@ -341,7 +341,7 @@ export class MissionCenter extends Phaser.Scene {
         this.cameras.main.setBounds(0, 0, bg.width, this.scale.height);
         
         this.player = createAvatar(this, this.playerXLocation, this.playerYLocation, this.playerDirection);
-        performIdles(this.player);
+        performIdles(this, this.player);
         this.cameras.main.startFollow(this.player);
 
         initializePlayerManager(this);

--- a/client/world/animations.js
+++ b/client/world/animations.js
@@ -249,8 +249,18 @@ export function performWink(player) {
     player.eyes.play(`wink-${player.eyes.texture.key}`);
 }
 
-export function performIdles(player) {
-    if (assets['hair']?.["female"]?.[player.hair.texture.key]?.["type"] == "sprite"){
+export function performIdles(scene, player) {
+    const boardsMetadata = scene.cache.json.get('boards_metadata');
+
+    if (
+        boardsMetadata &&
+        player.board &&
+        boardsMetadata[player.board.texture.key]?.type === 'sprite'
+    ) {
+        player.board.play(`idle-${player.board.texture.key}`);
+    }
+
+    if (assets['hair']?.['female']?.[player.hair.texture.key]?.['type'] === 'sprite') {
         player.hair.play(`idle-${player.hair.texture.key}`);
     }
 }

--- a/client/world/inventory.js
+++ b/client/world/inventory.js
@@ -162,7 +162,7 @@ export function openInventory(scene, player, room){
         previewPlayer.destroy();
 
         createAvatarAnimations(scene, player);
-        performIdles(player);
+        performIdles(scene, player);
     });
 
     closeInventory.on('pointerover', () => {

--- a/client/world/playerManager.js
+++ b/client/world/playerManager.js
@@ -83,7 +83,7 @@ export function initializePlayerManager(scene) {
             otherPlayer.depth = otherPlayer.y;
             scene.otherPlayers[id] = otherPlayer;
             createAvatarAnimations(scene, otherPlayer);
-            performIdles(otherPlayer);
+            performIdles(scene, otherPlayer);
         }
     };
 


### PR DESCRIPTION
## Summary
- update `performIdles` to accept the current scene and pull `boards_metadata` from the cache before animating hair and boards
- prepend scene argument to `performIdles` calls across scenes and systems

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689d7b5d34288324af29936cf9fb8002